### PR TITLE
Updated LdifReader to read file with multiple entries

### DIFF
--- a/src/LdifHelper/LdifReader.cs
+++ b/src/LdifHelper/LdifReader.cs
@@ -340,6 +340,7 @@ namespace LdifHelper
 
                             if (string.IsNullOrWhiteSpace(line))
                             {
+                                break;
                                 throw new LdifReaderException($"Line {ldifReader.lineNumber}: Invalid changetype modify entry, unexpected empty line.");
                             }
 
@@ -361,8 +362,11 @@ namespace LdifHelper
                         }
 
                         // Consume SEP.
-                        ldifReader.textReader.ReadLine();
-                        ldifReader.lineNumber++;
+                        if (!string.IsNullOrWhiteSpace(line))
+                        {
+                            ldifReader.textReader.ReadLine();
+                            ldifReader.lineNumber++;
+                        }
 
                         // Complete modify entry.
                         ldifReader.modifyEntries.Add(new ModSpec(modSpec, modSpecAttributeTypeString, values));


### PR DESCRIPTION
This change addresses an issue where the LdifReader could only read 1 change-modify entry per file. If a file contains more than 1 valid change-modify entry, then an exception would be thrown.

Example:
```
dn: CN=Ada Lovelace,OU=users,DC=company,DC=com
changetype: modify
add: description
description: another updated description


dn: CN=Niklaus Wirth,OU=users,DC=company,DC=com
changetype: modify
add: description
description: description update
```